### PR TITLE
chore: show warning for deprecated `preserveModules` option.

### DIFF
--- a/packages/vite-plugin-lib-inject-css/CHANGELOG.md
+++ b/packages/vite-plugin-lib-inject-css/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+- chore: show warnings for `preserveModules` also for deprecated `rollupOptions.preserveModules`. closed [#5](https://github.com/emosheeep/fe-tools/issues/5)
+
 # 1.1.0
 
 - fix: set `hoistTransitiveImports` internally by default to prevent tree-shaking from failure.

--- a/packages/vite-plugin-lib-inject-css/index.ts
+++ b/packages/vite-plugin-lib-inject-css/index.ts
@@ -34,8 +34,7 @@ export function libInjectCss(libOptions?: LibOptions): Plugin {
         ...options,
       }));
 
-      // preserve vite's default behavior
-      rollupOptions.output = Array.isArray(outputOptions)
+      rollupOptions.output = outputOptions.length === 1
         ? outputOptions[0]
         : outputOptions;
 

--- a/packages/vite-plugin-lib-inject-css/index.ts
+++ b/packages/vite-plugin-lib-inject-css/index.ts
@@ -69,13 +69,22 @@ export function libInjectCss(libOptions?: LibOptions): Plugin {
         );
       }
 
+      const createPreserveModulesWarning = (optionPath: string) => {
+        messages.push(
+          'When `' + optionPath + '` is `true`, ' +
+          'the association between chunk file and its css references will lose, ' +
+          'so the style code injection will be skipped.',
+        );
+      };
+
       if (outputOptions.some(v => v?.preserveModules === true)) {
         skipInject = true;
-        messages.push(
-          'When `rollupOptions.preserveModules` is `true`, ' +
-            'the association between chunk file and its css references will lose, ' +
-              'so the style code injection will be skipped.',
-        );
+        createPreserveModulesWarning('rollupOptions.output.preserveModules');
+      }
+
+      if (build.rollupOptions.preserveModules === true) {
+        skipInject = true;
+        createPreserveModulesWarning('rollupOptions.preserveModules');
       }
 
       messages.forEach(msg => console.log(`\n${color.cyan('[vite:lib-inject-css]:')} ${color.yellow(msg)}\n`));

--- a/playground/vite-plugin-lib-inject-css/vite.config.ts
+++ b/playground/vite-plugin-lib-inject-css/vite.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
       entry: scanEntries('src'),
       rollupOptions: {
         external: ['vue'],
+        output: {
+          // Put chunk files at <output>/chunks
+          chunkFileNames: 'chunks/[name].[hash].js',
+          // Put chunk styles at <output>/assets
+          assetFileNames: 'assets/[name][extname]',
+          entryFileNames: '[name].js',
+        },
       },
     }),
   ],


### PR DESCRIPTION
also for deprecated rollupOptions.preserveModules