### PR TITLE
fix: No css files emitted on SSR

### DIFF
--- a/packages/vite-plugin-lib-inject-css/CHANGELOG.md
+++ b/packages/vite-plugin-lib-inject-css/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+
+- feat: emit css files on SSR build. Closed [#12](https://github.com/emosheeep/fe-tools/issues/12).
+- docs: improve documentation.
+
 # 1.2.1
 
 - fix: cross-platform path handling. Closes [#9](https://github.com/emosheeep/fe-tools/issues/9).

--- a/packages/vite-plugin-lib-inject-css/README.md
+++ b/packages/vite-plugin-lib-inject-css/README.md
@@ -24,6 +24,7 @@ Note that this plugin only works with [library-mode](https://vitejs.dev/guide/bu
 
 - 💡 Multiple entires support.
 - ⚡️ Sourcemap support.
+- 💻 SSR building support.
 - 🛠 Out-of-box, tiny and pretty.
 
 # Motivation
@@ -55,17 +56,19 @@ export { Button, xxx };
 import { Button } from 'component-lib';
 ```
 
-The simplest way is to add a line `import './style.css';`; to the top of the generated file, multiple lines are multiple lines. As a library provider, we should **provide flexibility as much as possible**, and **delegate the task of how to handle these css files to the user's build tool**.
+The simplest way is to add a line `import './style.css';` to the top of the generated file, multiple lines are multiple lines. As a library provider, we should **provide flexibility as much as possible**, and **delegate the task of how to handle these css files to the user's build tool**.
 
-But most of the Vite plugins on the market that claim to automatically inject CSS are designed in a way use `document.createElement ('style')`, which is not graceful, and it assumes that the current is in the Browser's DOM environment.
+But most of the Vite plugins on the market that claim to automatically inject CSS are designed in a way use `document.createElement ('style')`, which is not graceful, and **it assumes that the current is in the Browser's DOM environment, which makes the library SSR-incompatible**.
 
-So the main problem becomes to **how do we know which style files are involved in one chunk file?**.
+Here's the reply([vite#issuecomment](https://github.com/vitejs/vite/issues/1579#issuecomment-763295757)) of the author of Vite, Evan You.
+
+So the main problem becomes to **how do we know which style files are involved in one chunk file**?
 
 In fact, vite adds a property named `viteMetadata` on each chunk file in plugin lifecycle, you can check [css.ts](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/css.ts) for further information.
 
 We can get which resources(include CSS files) are associated with current chunk file by using this property. Based on this, the plugin injects styles by using [renderChunk](https://rollupjs.org/plugin-development/#renderchunk) hook, which is the simplest and most effective way.
 
-Prefer to check source code to get more information.
+*Prefer to check plugin source code to get more information and welcome to make contribution*, which is simple enough(100+ lines).
 
 # Usage
 

--- a/packages/vite-plugin-lib-inject-css/index.ts
+++ b/packages/vite-plugin-lib-inject-css/index.ts
@@ -45,7 +45,7 @@ export function libInjectCss(libOptions?: LibOptions): Plugin {
           rollupOptions,
           /**
            * Must enable css code split, otherwise there's only one `style.css` and `chunk.viteMetadata.importedCss` will be empty.
-           * @see https://github.com/vitejs/vite/blob/HEAD/packages/vite/src/node/plugins/css.ts#L578-L579
+           * @see https://github.com/vitejs/vite/blob/HEAD/packages/vite/src/node/plugins/css.ts#L613
            */
           cssCodeSplit: true,
           /**

--- a/packages/vite-plugin-lib-inject-css/index.ts
+++ b/packages/vite-plugin-lib-inject-css/index.ts
@@ -48,6 +48,12 @@ export function libInjectCss(libOptions?: LibOptions): Plugin {
            * @see https://github.com/vitejs/vite/blob/HEAD/packages/vite/src/node/plugins/css.ts#L578-L579
            */
           cssCodeSplit: true,
+          /**
+           * Must emit assets on SSR, otherwise there won't be any CSS files generated and the import statements
+           * injected by this plugin will refer to an undefined module.
+           * @see https://github.com/vitejs/vite/blob/HEAD/packages/vite/src/node/plugins/asset.ts#L213-L218
+           */
+          ssrEmitAssets: true,
         },
       };
     },
@@ -62,8 +68,16 @@ export function libInjectCss(libOptions?: LibOptions): Plugin {
 
       if (build.lib && build.cssCodeSplit === false) {
         messages.push(
-          '`config.build.cssCodeSplit` is set `true` by the plugin internally in library mode, ' +
-          'but it seems to be `false` now. This may cause style code injection fail, ' +
+          '`config.build.cssCodeSplit` is set to `true` by the plugin internally in library mode, ' +
+          'but it seems to be `false` now. This may cause style code injection to fail, ' +
+          'please check the configuration to prevent this option from being modified.',
+        );
+      }
+
+      if (build.ssr && build.ssrEmitAssets === false) {
+        messages.push(
+          '`config.build.ssrEmitAssets` is set to `true` by the plugin internally in library mode, ' +
+          'but it seems to be `false` now. This may cause style code injection to fail on SSR, ' +
           'please check the configuration to prevent this option from being modified.',
         );
       }

--- a/packages/vite-plugin-lib-inject-css/package.json
+++ b/packages/vite-plugin-lib-inject-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-lib-inject-css",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Inject css at the top of chunk file in lib mode using `import` statement, support multiple entries.",
   "author": "秦旭洋 <emosheep@qq.com>",
   "packageManager": "pnpm@8.3.1",


### PR DESCRIPTION
Fixes #12 

Apparently, Vite doesn't emit any assets on SSR by default, `build.ssrEmitAssets` has to be explicitly set to `true` to ensure they are emitted. Unfortunately, this option is not documented making it pretty hard to figure out.

Similar to how `cssCodeSplit` is set to `true` by the plugin, this PR makes sure that `ssrEmitAssets` is also set to `true` internally.

You can give it a try here: https://stackblitz.com/edit/vue3-vite-starter-f7mk9t
If you run `npm run build` in a new terminal tab, you'll see the css files generated as expected.