### PR TITLE
docs: updated format to formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export default defineConfig({
   ],
   build: {
     lib: {
-      format: ['es'],
+      formats: ['es'],
       entry: {
         index: 'src/index.ts',
         button: 'src/components/button/index.ts',


### PR DESCRIPTION
`format` does not exist in type `LibraryOptions`